### PR TITLE
docker: fix libllama build

### DIFF
--- a/docker/rootfs/etc/apt/apt.conf.d/99local
+++ b/docker/rootfs/etc/apt/apt.conf.d/99local
@@ -1,0 +1,2 @@
+APT::Install-Recommends "false";
+APT::Install-Suggests "false";

--- a/docker/rootfs/etc/apt/sources.list.d/python-ppa.list
+++ b/docker/rootfs/etc/apt/sources.list.d/python-ppa.list
@@ -1,0 +1,2 @@
+deb https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main
+deb-src https://ppa.launchpadcontent.net/deadsnakes/ppa/ubuntu focal main

--- a/docker/rootfs/usr/bin/apt-cleanup
+++ b/docker/rootfs/usr/bin/apt-cleanup
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+rm -rf /var/lib/apt/lists/

--- a/docker/rootfs/usr/bin/apt-dpkg-wrap
+++ b/docker/rootfs/usr/bin/apt-dpkg-wrap
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export LC_ALL=C
+export DEBIAN_FRONTEND=noninteractive
+
+bin=$1
+shift
+exec "$bin" "$@"

--- a/docker/run-skynet.sh
+++ b/docker/run-skynet.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+cd /app
+. .venv/bin/activate
+exec python3.11 skynet/main.py


### PR DESCRIPTION
When installing dependencies with Poetry the env vars that llama-cpp requires seem to not be taken into account, unlike when using pip.

In order to fix this, export the Poetry dependencies into pip format and use that to install them.