### PR TITLE
jobs: fix jobs ignoring queue priority

### DIFF
--- a/skynet/modules/ttt/summaries/jobs.py
+++ b/skynet/modules/ttt/summaries/jobs.py
@@ -18,7 +18,7 @@ from .v1.models import DocumentPayload, Job, JobId, JobStatus, JobType
 
 log = get_logger(__name__)
 
-TIME_BETWEEN_JOBS_CHECK = 3
+TIME_BETWEEN_JOBS_CHECK = 2
 PENDING_JOBS_KEY = "jobs:pending"
 RUNNING_JOBS_KEY = "jobs:running"
 
@@ -67,13 +67,10 @@ async def create_job(job_type: JobType, payload: DocumentPayload) -> JobId:
 
     await db.set(job_id, Job.model_dump_json(job))
 
-    log.info(f"Created job {job.id}")
+    log.info(f"Created job {job.id}.")
 
-    if can_run_next_job():
-        create_run_job_task(job)
-    else:
-        await db.rpush(PENDING_JOBS_KEY, job_id)
-        await update_summary_queue_metric()
+    await db.rpush(PENDING_JOBS_KEY, job_id)
+    await update_summary_queue_metric()
 
     return JobId(id=job_id)
 

--- a/skynet/modules/ttt/summaries/jobs_test.py
+++ b/skynet/modules/ttt/summaries/jobs_test.py
@@ -17,19 +17,6 @@ def default_session_fixture() -> Iterator[None]:
 
 class TestCreateJob:
     @pytest.mark.asyncio
-    async def test_creates_run_job(self, mocker):
-        '''Test that a job run task is created.'''
-
-        mocker.patch('skynet.modules.ttt.summaries.jobs.create_run_job_task')
-
-        from skynet.modules.ttt.summaries.jobs import create_job, create_run_job_task
-
-        job_id = await create_job(JobType.SUMMARY, DocumentPayload(text='test'))
-
-        create_run_job_task.assert_called_once()
-        assert job_id.id is not None
-
-    @pytest.mark.asyncio
     async def test_queues_job(self, mocker):
         '''Test that a job is queued and queue size metric is updated.'''
 


### PR DESCRIPTION
* Fixes cases where newly created jobs do not account for existing queue items when creation occurs between previous job being done and the next check interval.
* Decrease check interval to 2 seconds