### PR TITLE
feat: dismiss timed out jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ models
 .DS_Store
 .env
 .idea
+llama.log
+dump.rdb

--- a/skynet/modules/monitoring.py
+++ b/skynet/modules/monitoring.py
@@ -43,6 +43,13 @@ SUMMARY_QUEUE_SIZE_METRIC = Gauge(
     subsystem=PROMETHEUS_SUMMARIES_SUBSYSTEM,
 )
 
+SUMMARY_ERROR_COUNTER = Counter(
+    'summary_errors',
+    documentation='Number of jobs that have failed',
+    namespace=PROMETHEUS_NAMESPACE,
+    subsystem=PROMETHEUS_SUMMARIES_SUBSYSTEM,
+)
+
 CONNECTIONS_METRIC = Gauge(
     'LiveWsConnections',
     documentation='Number of active WS connections',
@@ -72,9 +79,9 @@ TRANSCRIBE_DURATION_METRIC = Histogram(
     buckets=[x / 10.0 for x in range(1, 31)],
 )
 
-FORCED_EXIT_COUNTER = Counter(
+OPENAI_API_RESTART_COUNTER = Counter(
     'forced_exit',
-    documentation='Number of forced exits',
+    documentation='Number of restarts of the OpenAI API server',
     namespace=PROMETHEUS_NAMESPACE,
     subsystem=PROMETHEUS_SUMMARIES_SUBSYSTEM,
 )

--- a/skynet/modules/ttt/openai_api/app.py
+++ b/skynet/modules/ttt/openai_api/app.py
@@ -9,13 +9,18 @@ from skynet.env import (
     openai_api_server_port,
 )
 from skynet.logs import get_logger
+from skynet.modules.monitoring import OPENAI_API_RESTART_COUNTER
 
 proc = None
+
 log = get_logger(__name__)
 
 
 def initialize():
+    log.info('Starting OpenAI API server...')
+
     global proc
+
     proc = subprocess.Popen(
         f'{openai_api_server_path} \
             -m {llama_path} \
@@ -33,8 +38,18 @@ def initialize():
 
 
 def destroy():
+    log.info('Killing OpenAI API subprocess...')
+
     proc.kill()
-    log.info('OpenAI API subprocess destroyed')
 
 
-__all__ = ['destroy', 'initialize']
+def restart():
+    log.info('Restarting OpenAI API server...')
+
+    OPENAI_API_RESTART_COUNTER.inc()
+
+    destroy()
+    initialize()
+
+
+__all__ = ['destroy', 'initialize', 'restart']

--- a/skynet/modules/ttt/summaries/jobs_test.py
+++ b/skynet/modules/ttt/summaries/jobs_test.py
@@ -86,7 +86,7 @@ class TestRunJob:
 
         from skynet.modules.ttt.summaries.jobs import process_open_ai, run_job
 
-        run_job_fixture.patch('skynet.modules.ttt.summaries.jobs.get_credentials', return_value={'api_key': 'api_key'})
+        run_job_fixture.patch('skynet.modules.ttt.summaries.jobs.get_credentials', return_value={'secret': 'api_key'})
 
         await run_job(
             Job(

--- a/skynet/modules/ttt/summaries/processor.py
+++ b/skynet/modules/ttt/summaries/processor.py
@@ -35,6 +35,7 @@ def initialize():
         api_key='placeholder',  # use a placeholder value to bypass validation, and allow the custom base url to be used
         base_url=openai_api_base_url,
         default_headers={"X-Skynet-UUID": app_uuid},
+        max_retries=0,
         temperature=0,
     )
 

--- a/skynet/utils.py
+++ b/skynet/utils.py
@@ -1,12 +1,9 @@
-import os
-
 import uvicorn
 from fastapi import APIRouter, Depends
 
 from skynet.auth.bearer import JWTBearer
 from skynet.env import bypass_auth, ws_max_ping_interval, ws_max_ping_timeout, ws_max_queue_size, ws_max_size_bytes
 from skynet.logs import get_logger, uvicorn_log_config
-from skynet.modules.monitoring import FORCED_EXIT_COUNTER
 
 log = get_logger(__name__)
 
@@ -36,11 +33,3 @@ async def create_webserver(app, port):
     )
     server = uvicorn.Server(server_config)
     await server.serve()
-
-
-def kill_process():
-    log.info('Killing current process')
-
-    FORCED_EXIT_COUNTER.inc()
-
-    os._exit(1)


### PR DESCRIPTION
* do not re-process timed out jobs, just marked them with error status
* avoid restarting the whole process on job timeout, but rather restart just the openai api server
* add a redis collection for storing jobs keys that errored out
* add metrics for number of error jobs and number of restarts
* fix broken unit test for OpenAI execution
* disable retries for local llm execution