### PR TITLE
feat: add ability to use OCI per customer

### DIFF
--- a/skynet/auth/user_info.py
+++ b/skynet/auth/user_info.py
@@ -15,6 +15,7 @@ credentials = dict()
 class CredentialsType(Enum):
     OPENAI = 'OPENAI'
     AZURE_OPENAI = 'AZURE_OPENAI'
+    OCI = 'OCI'
 
 
 async def open_yaml(file_path):

--- a/skynet/modules/ttt/summaries/v1/models.py
+++ b/skynet/modules/ttt/summaries/v1/models.py
@@ -68,6 +68,7 @@ class Processors(Enum):
     OPENAI = 'OPENAI'
     AZURE = 'AZURE'
     LOCAL = 'LOCAL'
+    OCI = 'OCI'
 
 
 class JobStatus(Enum):


### PR DESCRIPTION
This is slightly different than the OpenAI / AzuerOpenAI runners. Instead, OCI credentials are configured globally for a given Skynet runner, just like the local one, and if configured, requests shall be sent to OCI rather than to the local running llama.

The ability to run without a local llm directly targetting OCI is still retained.