### PR TITLE
feat: patch OCI library to be async

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ifneq (,$(wildcard ./.env))
 endif
 
 GIT_HASH ?= $(shell git rev-parse --short HEAD)
-PLATFORMS ?= linux/amd64
+PLATFORMS ?= linux/arm64
 
 _login:
 	${DOCKER_LOGIN_CMD}

--- a/skynet/modules/ttt/oci_utils.py
+++ b/skynet/modules/ttt/oci_utils.py
@@ -1,0 +1,34 @@
+import asyncio
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, List, Optional
+
+from langchain_community.chat_models import ChatOCIGenAI
+
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.messages import BaseMessage
+from langchain_core.outputs import ChatResult
+
+executor = None
+executor_max_workers = 10  # Matches the connection pool size used by Requests
+
+
+class AsyncChatOCIGenAI(ChatOCIGenAI):
+    async def _agenerate(
+        self,
+        messages: List[BaseMessage],
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        global executor
+
+        if executor is None:
+            executor = ThreadPoolExecutor(max_workers=executor_max_workers)
+
+        loop = asyncio.get_running_loop()
+        result = await loop.run_in_executor(executor, self._generate, messages, stop, run_manager, **kwargs)
+        return result
+
+
+__all__ = ['AsyncChatOCIGenAI']

--- a/skynet/modules/ttt/processor.py
+++ b/skynet/modules/ttt/processor.py
@@ -1,7 +1,6 @@
 from langchain.chains.summarize import load_summarize_chain
 from langchain.prompts import ChatPromptTemplate
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from langchain_community.chat_models import ChatOCIGenAI
 from langchain_core.documents import Document
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
@@ -35,6 +34,8 @@ from skynet.modules.ttt.summaries.prompts.summary import (
     summary_text,
 )
 from skynet.modules.ttt.summaries.v1.models import DocumentPayload, HintType, JobType, Processors
+
+from .oci_utils import AsyncChatOCIGenAI
 
 log = get_logger(__name__)
 
@@ -80,7 +81,7 @@ def get_local_llm(**kwargs):
         global oci_llm
 
         if oci_llm is None:
-            oci_llm = ChatOCIGenAI(
+            oci_llm = AsyncChatOCIGenAI(
                 model_id=oci_model_id,
                 service_endpoint=oci_service_endpoint,
                 compartment_id=oci_compartment_id,

--- a/skynet/modules/ttt/summaries/jobs.py
+++ b/skynet/modules/ttt/summaries/jobs.py
@@ -22,7 +22,7 @@ from .v1.models import DocumentMetadata, DocumentPayload, Job, JobId, JobStatus,
 
 log = get_logger(__name__)
 
-TIME_BETWEEN_JOBS_CHECK = 1
+TIME_BETWEEN_JOBS_CHECK = 0.1
 TIME_BETWEEN_JOBS_CHECK_ON_ERROR = 10
 
 PENDING_JOBS_KEY = "jobs:pending"


### PR DESCRIPTION
The OCI client uses Requests under the hood, which is blocking. Patch it by running it in a thread pool, with a max size of 10, which matches the connection pool size.