### PR TITLE
fix(docker) fix not being able to read package version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ RUN \
     apt-dpkg-wrap apt-get install -y build-essential python3.11 python3.11-venv
 
 COPY requirements*.txt /app/
+COPY pyproject.toml /app/
+COPY skynet /app/skynet
 
 WORKDIR /app
 
@@ -27,10 +29,10 @@ RUN \
     . .venv/bin/activate && \
     if [ "$BUILD_WITH_VLLM" = "1" ]; then \
         echo "Building with VLLM"; \
-        pip install -r requirements-vllm.txt; \
+        pip install -r requirements-vllm.txt . ; \
     else \
         echo "Building without VLLM"; \
-        pip install -r requirements.txt; \
+        pip install -r requirements.txt . ; \
     fi
 
 ## Build ffmpeg
@@ -78,7 +80,6 @@ COPY --from=ffmpeg_builder /usr/local/include /usr/local/include
 COPY --from=ffmpeg_builder /usr/local/lib/lib* /usr/local/lib/
 COPY --from=ffmpeg_builder /usr/local/lib/pkgconfig /usr/local/lib/pkgconfig
 COPY --chown=jitsi:jitsi --from=builder /app/.venv /app/.venv
-COPY --chown=jitsi:jitsi /skynet /app/skynet/
 
 RUN \
     apt-get update && \

--- a/docker/run-skynet.sh
+++ b/docker/run-skynet.sh
@@ -2,4 +2,4 @@
 
 cd /app
 . .venv/bin/activate
-exec python3.11 skynet/main.py
+exec python -m skynet.main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,7 @@
 [tool.poetry]
 name = "skynet"
 version = "0.1.0"
-description = ""
 authors = ["Jitsi Team <team@jitsi.org>"]
-readme = "README.md"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"


### PR DESCRIPTION
We were only installing the dependencies, but not Skynet itself. Do so, and this way we don't need to copy the files later as they are part of the venv.