### PR TITLE
Download ms-marco-MultiBERT-L-12 model only if 'assistant' feature is enabled

### DIFF
--- a/skynet/modules/ttt/processor.py
+++ b/skynet/modules/ttt/processor.py
@@ -32,6 +32,7 @@ from skynet.modules.ttt.summaries.prompts.summary import (
     summary_text,
 )
 from skynet.modules.ttt.summaries.v1.models import DocumentPayload, HintType, Job, JobType, Processors
+from skynet.env import modules
 
 log = get_logger(__name__)
 
@@ -63,7 +64,7 @@ def format_docs(docs: list[Document]) -> str:
     )
 
 
-compressor = FlashrankRerank()
+compressor = FlashrankRerank() if 'assistant' in modules else None
 
 
 async def assist(model: BaseChatModel, payload: AssistantDocumentPayload, customer_id: Optional[str] = None) -> str:


### PR DESCRIPTION
Initialize compressor variable (which is used only in assist function below) only if 'assistant' feature is enabled. Otherwise compressor variable is always initialized and 'ms-marco-MultiBERT-L-12' model is downloaded at app startup even if 'assistant' featured is not planned to be used.