### PR TITLE
feat: add metric for map-reduce chunking operations

### DIFF
--- a/skynet/modules/monitoring.py
+++ b/skynet/modules/monitoring.py
@@ -105,6 +105,14 @@ OPENAI_API_RESTART_COUNTER = Counter(
     subsystem=PROMETHEUS_SUMMARIES_SUBSYSTEM,
 )
 
+MAP_REDUCE_CHUNKING_COUNTER = Counter(
+    'map_reduce_chunking_total',
+    documentation='Number of times map-reduce chunking was used for long inputs',
+    namespace=PROMETHEUS_NAMESPACE,
+    subsystem=PROMETHEUS_SUMMARIES_SUBSYSTEM,
+    labelnames=['job_type'],
+)
+
 instrumentator = Instrumentator(
     excluded_handlers=["/healthz", "/metrics"],
 )

--- a/skynet/modules/ttt/processor.py
+++ b/skynet/modules/ttt/processor.py
@@ -16,6 +16,7 @@ from skynet.constants import response_prefix
 
 from skynet.env import llama_n_ctx, modules, use_oci
 from skynet.logs import get_logger
+from skynet.modules.monitoring import MAP_REDUCE_CHUNKING_COUNTER
 from skynet.modules.ttt.assistant.constants import assistant_rag_question_extractor
 from skynet.modules.ttt.assistant.utils import get_assistant_chat_messages
 from skynet.modules.ttt.assistant.v1.models import AssistantDocumentPayload
@@ -158,6 +159,9 @@ async def summarize(model: BaseChatModel, payload: DocumentPayload, job_type: Jo
         chunk_size = num_tokens // num_chunks
 
         log.info(f'Splitting text into {num_chunks} chunks of {chunk_size} tokens')
+
+        # Record map-reduce chunking metric
+        MAP_REDUCE_CHUNKING_COUNTER.labels(job_type=job_type.value).inc()
 
         text_splitter = RecursiveCharacterTextSplitter.from_tiktoken_encoder(chunk_size=chunk_size, chunk_overlap=100)
         docs = text_splitter.create_documents([text])


### PR DESCRIPTION
## Summary
- Added `MAP_REDUCE_CHUNKING_COUNTER` metric to track when long inputs trigger map-reduce chunking in the summarization pipeline
- The metric includes `job_type` label to distinguish between summary, action items, and table of contents operations
- This helps monitor performance and resource usage patterns for large document processing

## Changes
- Added new Prometheus counter metric in `skynet/modules/monitoring.py`
- Integrated metric tracking in `skynet/modules/ttt/processor.py` when chunking is triggered
- Metric increments when input text exceeds token threshold and requires map-reduce processing

## Test plan
- [ ] Deploy to staging environment
- [ ] Process large documents that trigger chunking
- [ ] Verify metric appears in Prometheus metrics endpoint
- [ ] Confirm metric labels are properly set

🤖 Generated with Claude Code