### PR TITLE
feat(whisper): Track connections in a list, not keyed by meeting_id

### DIFF
--- a/skynet/modules/stt/streaming_whisper/app.py
+++ b/skynet/modules/stt/streaming_whisper/app.py
@@ -31,5 +31,6 @@ async def websocket_endpoint(websocket: WebSocket, meeting_id: str, auth_token: 
             if len(chunk) == 1 and ord(b'' + chunk) == 0:
                 log.info(f'Received disconnect message for {connection.meeting_id}')
                 await ws_connection_manager.disconnect(connection)
+                connected = False
                 break
             await ws_connection_manager.process(connection, chunk, utils.now())

--- a/skynet/modules/stt/streaming_whisper/app.py
+++ b/skynet/modules/stt/streaming_whisper/app.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, WebSocketException
 
 from skynet.logs import get_logger
 from skynet.modules.stt.streaming_whisper.connection_manager import ConnectionManager
@@ -14,23 +14,23 @@ app = FastAPI()  # No need for CORS middleware
 async def websocket_endpoint(websocket: WebSocket, meeting_id: str, auth_token: str | None = None):
     connection = await ws_connection_manager.connect(websocket, meeting_id, auth_token)
     if connection:
-        connected = True
-        while connected:
+        while connection.connected:
             try:
                 chunk = await websocket.receive_bytes()
             except WebSocketDisconnect as dc:
                 log.info(f'Meeting {connection.meeting_id} has ended')
                 await ws_connection_manager.disconnect(connection, already_closed=True)
-                connected = False
                 break 
-            except Exception as err:
-                log.warning(f'Expected bytes, received something else, disconnecting {connection.meeting_id}. Error: \n{err}')
+            except WebSocketException as wserr:
+                log.warning(f'Error on websocket {connection.meeting_id}. Error {wserr.__class__}: \n{wserr}')
                 await ws_connection_manager.disconnect(connection)
-                connected = False
+                break
+            except Exception as err:
+                log.warning(f'Expected bytes, received something else, disconnecting {connection.meeting_id}. Error {err.__class__}: \n{err}')
+                await ws_connection_manager.disconnect(connection)
                 break
             if len(chunk) == 1 and ord(b'' + chunk) == 0:
                 log.info(f'Received disconnect message for {connection.meeting_id}')
                 await ws_connection_manager.disconnect(connection)
-                connected = False
                 break
             await ws_connection_manager.process(connection, chunk, utils.now())

--- a/skynet/modules/stt/streaming_whisper/app.py
+++ b/skynet/modules/stt/streaming_whisper/app.py
@@ -12,20 +12,24 @@ app = FastAPI()  # No need for CORS middleware
 
 @app.websocket('/ws/{meeting_id}')
 async def websocket_endpoint(websocket: WebSocket, meeting_id: str, auth_token: str | None = None):
-    await ws_connection_manager.connect(websocket, meeting_id, auth_token)
-    try:
-        while True:
+    connection = await ws_connection_manager.connect(websocket, meeting_id, auth_token)
+    if connection:
+        connected = True
+        while connected:
             try:
                 chunk = await websocket.receive_bytes()
+            except WebSocketDisconnect as dc:
+                log.info(f'Meeting {connection.meeting_id} has ended')
+                await ws_connection_manager.disconnect_connection(connection, already_closed=True)
+                connected = False
+                break 
             except Exception as err:
-                log.warning(f'Expected bytes, received something else, disconnecting {meeting_id}. Error: \n{err}')
-                ws_connection_manager.disconnect(meeting_id)
+                log.warning(f'Expected bytes, received something else, disconnecting {connection.meeting_id}. Error: \n{err}')
+                await ws_connection_manager.disconnect_connection(connection)
+                connected = False
                 break
             if len(chunk) == 1 and ord(b'' + chunk) == 0:
-                log.info(f'Received disconnect message for {meeting_id}')
-                ws_connection_manager.disconnect(meeting_id)
+                log.info(f'Received disconnect message for {connection.meeting_id}')
+                await ws_connection_manager.disconnect_connection(connection)
                 break
-            await ws_connection_manager.process(meeting_id, chunk, utils.now())
-    except WebSocketDisconnect:
-        ws_connection_manager.disconnect(meeting_id)
-        log.info(f'Meeting {meeting_id} has ended')
+            await ws_connection_manager.process(connection, chunk, utils.now())

--- a/skynet/modules/stt/streaming_whisper/app.py
+++ b/skynet/modules/stt/streaming_whisper/app.py
@@ -20,16 +20,16 @@ async def websocket_endpoint(websocket: WebSocket, meeting_id: str, auth_token: 
                 chunk = await websocket.receive_bytes()
             except WebSocketDisconnect as dc:
                 log.info(f'Meeting {connection.meeting_id} has ended')
-                await ws_connection_manager.disconnect_connection(connection, already_closed=True)
+                await ws_connection_manager.disconnect(connection, already_closed=True)
                 connected = False
                 break 
             except Exception as err:
                 log.warning(f'Expected bytes, received something else, disconnecting {connection.meeting_id}. Error: \n{err}')
-                await ws_connection_manager.disconnect_connection(connection)
+                await ws_connection_manager.disconnect(connection)
                 connected = False
                 break
             if len(chunk) == 1 and ord(b'' + chunk) == 0:
                 log.info(f'Received disconnect message for {connection.meeting_id}')
-                await ws_connection_manager.disconnect_connection(connection)
+                await ws_connection_manager.disconnect(connection)
                 break
             await ws_connection_manager.process(connection, chunk, utils.now())

--- a/skynet/modules/stt/streaming_whisper/connection_manager.py
+++ b/skynet/modules/stt/streaming_whisper/connection_manager.py
@@ -44,12 +44,12 @@ class ConnectionManager:
         
         try:
             results = await connection.process(chunk, chunk_timestamp)
-            await self.send_to_connection(connection, results)
+            await self.send(connection, results)
         except Exception as e:
             log.error(f'Error processing chunk for meeting {connection.meeting_id}: {e}')
             self.disconnect(connection)
 
-    async def send_to_connection(self, connection: MeetingConnection, results: list[utils.TranscriptionResponse] | None):
+    async def send(self, connection: MeetingConnection, results: list[utils.TranscriptionResponse] | None):
         if results is not None:
             for result in results:
                 try:
@@ -86,5 +86,5 @@ class ConnectionManager:
                     if diff > whisper_flush_interval and len(state.working_audio) > 0 and not state.is_transcribing:
                         log.info(f'Forcing a transcription in meeting {connection.meeting_id} for {participant}')
                         results = await connection.force_transcription(participant)
-                        await self.send_to_connection(connection, results)
+                        await self.send(connection, results)
             await asyncio.sleep(1)

--- a/skynet/modules/stt/streaming_whisper/connection_manager.py
+++ b/skynet/modules/stt/streaming_whisper/connection_manager.py
@@ -57,6 +57,7 @@ class ConnectionManager:
                 except WebSocketDisconnect as e:
                     log.warning(f'Meeting {connection.meeting_id}: the connection was closed before sending all results: {e}')
                     await self.disconnect(connection, True)
+                    break
                 except Exception as ex:
                     log.error(f'Meeting {connection.meeting_id}: exception while sending transcription results {ex}')
 
@@ -67,6 +68,9 @@ class ConnectionManager:
             log.warning(f'The connection for meeting {connection.meeting_id} doesn\'t exist in the list anymore.')
         if not already_closed:
             await connection.close()
+        else:
+            # mark connection as disconnected
+            connection.disconnect()
         dec_ws_conn_count()
 
     async def flush_working_audio_worker(self):

--- a/skynet/modules/stt/streaming_whisper/connection_manager.py
+++ b/skynet/modules/stt/streaming_whisper/connection_manager.py
@@ -47,7 +47,7 @@ class ConnectionManager:
             await self.send(connection, results)
         except Exception as e:
             log.error(f'Error processing chunk for meeting {connection.meeting_id}: {e}')
-            self.disconnect(connection)
+            await self.disconnect(connection)
 
     async def send(self, connection: MeetingConnection, results: list[utils.TranscriptionResponse] | None):
         if results is not None:
@@ -56,7 +56,7 @@ class ConnectionManager:
                     await connection.ws.send_json(result.model_dump())
                 except WebSocketDisconnect as e:
                     log.warning(f'Meeting {connection.meeting_id}: the connection was closed before sending all results: {e}')
-                    self.disconnect(connection)
+                    await self.disconnect(connection, True)
                 except Exception as ex:
                     log.error(f'Meeting {connection.meeting_id}: exception while sending transcription results {ex}')
 

--- a/skynet/modules/stt/streaming_whisper/meeting_connection.py
+++ b/skynet/modules/stt/streaming_whisper/meeting_connection.py
@@ -24,6 +24,7 @@ class MeetingConnection:
     meeting_language: str | None
     meeting_id: str
     ws: WebSocket
+    connected: True
 
     def __init__(self, ws: WebSocket, meeting_id: str):
         self.participants = {}
@@ -33,6 +34,7 @@ class MeetingConnection:
         self.previous_transcription_store = []
         self.meeting_language = None
         self.tokenizer = None
+        self.connected = True
 
     async def update_initial_prompt(self, previous_payloads: list[utils.TranscriptionResponse]):
         for payload in previous_payloads:
@@ -72,5 +74,9 @@ class MeetingConnection:
             return payloads
         return None
 
+    def disconnect(self):
+        self.connected = False
+
     async def close(self):
         await self.ws.close()
+        self.disconnect()

--- a/skynet/modules/stt/streaming_whisper/meeting_connection.py
+++ b/skynet/modules/stt/streaming_whisper/meeting_connection.py
@@ -73,9 +73,4 @@ class MeetingConnection:
         return None
 
     async def close(self):
-        try:
-            await self.ws.close()
-        except Exception as e:
-            log.debug(f'Websocket already closed.')
-            pass
-
+        await self.ws.close()

--- a/skynet/modules/stt/streaming_whisper/meeting_connection.py
+++ b/skynet/modules/stt/streaming_whisper/meeting_connection.py
@@ -22,10 +22,12 @@ class MeetingConnection:
     previous_transcription_store: List[List[int]]
     tokenizer: Tokenizer | None
     meeting_language: str | None
+    meeting_id: str
 
-    def __init__(self, ws: WebSocket):
+    def __init__(self, ws: WebSocket, meeting_id: str):
         self.participants = {}
         self.ws = ws
+        self.meeting_id = meeting_id
         self.previous_transcription_tokens = []
         self.previous_transcription_store = []
         self.meeting_language = None

--- a/skynet/modules/stt/streaming_whisper/meeting_connection.py
+++ b/skynet/modules/stt/streaming_whisper/meeting_connection.py
@@ -23,6 +23,7 @@ class MeetingConnection:
     tokenizer: Tokenizer | None
     meeting_language: str | None
     meeting_id: str
+    ws: WebSocket
 
     def __init__(self, ws: WebSocket, meeting_id: str):
         self.participants = {}
@@ -70,3 +71,11 @@ class MeetingConnection:
                 await self.update_initial_prompt(payloads)
             return payloads
         return None
+
+    async def close(self):
+        try:
+            await self.ws.close()
+        except Exception as e:
+            log.debug(f'Websocket already closed.')
+            pass
+

--- a/skynet/modules/stt/vox/app.py
+++ b/skynet/modules/stt/vox/app.py
@@ -75,7 +75,7 @@ async def websocket_endpoint(websocket: WebSocket, auth_token: str | None = None
                     participant['raw'] = b''
 
         except WebSocketDisconnect:
-            ws_connection_manager.disconnect_connection(connection)
+            ws_connection_manager.disconnect(connection)
             data_map.clear()
             log.info(f'Session {session_id} has ended')
             break

--- a/skynet/modules/stt/vox/app.py
+++ b/skynet/modules/stt/vox/app.py
@@ -75,7 +75,7 @@ async def websocket_endpoint(websocket: WebSocket, auth_token: str | None = None
                     participant['raw'] = b''
 
         except WebSocketDisconnect:
-            ws_connection_manager.disconnect(connection)
+            ws_connection_manager.disconnect(connection, True)
             data_map.clear()
             log.info(f'Session {session_id} has ended')
             break

--- a/skynet/modules/stt/vox/app.py
+++ b/skynet/modules/stt/vox/app.py
@@ -23,7 +23,7 @@ async def websocket_endpoint(websocket: WebSocket, auth_token: str | None = None
     decoder = PcmaDecoder()
     resampler = PcmResampler()
     session_id = utils.Uuid7().get()
-    await ws_connection_manager.connect(websocket, session_id, auth_token)
+    connection = await ws_connection_manager.connect(websocket, session_id, auth_token)
 
     data_map = dict()
     resampler = None
@@ -64,7 +64,7 @@ async def websocket_endpoint(websocket: WebSocket, auth_token: str | None = None
 
                     task = asyncio.create_task(
                         ws_connection_manager.process(
-                            session_id, participant['header'] + decoded_raw, media['timestamp']
+                            connection, participant['header'] + decoded_raw, media['timestamp']
                         )
                     )
 
@@ -75,7 +75,7 @@ async def websocket_endpoint(websocket: WebSocket, auth_token: str | None = None
                     participant['raw'] = b''
 
         except WebSocketDisconnect:
-            ws_connection_manager.disconnect(session_id)
+            ws_connection_manager.disconnect_connection(connection)
             data_map.clear()
             log.info(f'Session {session_id} has ended')
             break

--- a/skynet/modules/stt/vox/connection_manager.py
+++ b/skynet/modules/stt/vox/connection_manager.py
@@ -26,6 +26,6 @@ class ConnectionManager(BaseConnectionManager):
                 log.debug(f'Participant {result.participant_id} result: {result.text}')
             except WebSocketDisconnect as e:
                 log.warning(f'Session {connection.meeting_id}: the connection was closed before sending all results: {e}')
-                self.disconnect_connection(connection)
+                self.disconnect(connection)
             except Exception as ex:
                 log.error(f'Session {connection.meeting_id}: exception while sending transcription results {ex}')

--- a/skynet/modules/stt/vox/connection_manager.py
+++ b/skynet/modules/stt/vox/connection_manager.py
@@ -26,6 +26,6 @@ class ConnectionManager(BaseConnectionManager):
                 log.debug(f'Participant {result.participant_id} result: {result.text}')
             except WebSocketDisconnect as e:
                 log.warning(f'Session {connection.meeting_id}: the connection was closed before sending all results: {e}')
-                self.disconnect(connection)
+                self.disconnect(connection, True)
             except Exception as ex:
                 log.error(f'Session {connection.meeting_id}: exception while sending transcription results {ex}')

--- a/skynet/modules/stt/vox/connection_manager.py
+++ b/skynet/modules/stt/vox/connection_manager.py
@@ -1,34 +1,31 @@
 from fastapi import WebSocketDisconnect
 
 from skynet.logs import get_logger
-from skynet.modules.stt.streaming_whisper.connection_manager import ConnectionManager as BaseConnectionManager
+from skynet.modules.stt.streaming_whisper.connection_manager import ConnectionManager as BaseConnectionManager, MeetingConnection
 from skynet.modules.stt.streaming_whisper.utils.utils import TranscriptionResponse
 
 log = get_logger(__name__)
 
 
 class ConnectionManager(BaseConnectionManager):
-    async def send(self, session_id: str, results: list[TranscriptionResponse] | None):
+    async def send_to_connection(self, connection: MeetingConnection, results: list[TranscriptionResponse] | None):
         if results is None:
             return
 
         final_results = [r for r in results if r.type == 'final']
-        connections = [conn for conn in self.connections if conn.meeting_id == session_id]
-        
-        for connection in connections:
-            for result in final_results:
-                try:
-                    await connection.ws.send_json(
-                        {
-                            'timestamp': result.ts,
-                            'tag': result.participant_id,
-                            'final': result.text,
-                            'language': 'en',
-                        }
-                    )
-                    log.debug(f'Participant {result.participant_id} result: {result.text}')
-                except WebSocketDisconnect as e:
-                    log.warning(f'Session {session_id}: the connection was closed before sending all results: {e}')
-                    self.disconnect_connection(connection)
-                except Exception as ex:
-                    log.error(f'Session {session_id}: exception while sending transcription results {ex}')
+        for result in final_results:
+            try:
+                await connection.ws.send_json(
+                    {
+                        'timestamp': result.ts,
+                        'tag': result.participant_id,
+                        'final': result.text,
+                        'language': 'en',
+                    }
+                )
+                log.debug(f'Participant {result.participant_id} result: {result.text}')
+            except WebSocketDisconnect as e:
+                log.warning(f'Session {connection.meeting_id}: the connection was closed before sending all results: {e}')
+                self.disconnect_connection(connection)
+            except Exception as ex:
+                log.error(f'Session {connection.meeting_id}: exception while sending transcription results {ex}')

--- a/skynet/modules/stt/vox/connection_manager.py
+++ b/skynet/modules/stt/vox/connection_manager.py
@@ -8,7 +8,7 @@ log = get_logger(__name__)
 
 
 class ConnectionManager(BaseConnectionManager):
-    async def send_to_connection(self, connection: MeetingConnection, results: list[TranscriptionResponse] | None):
+    async def send(self, connection: MeetingConnection, results: list[TranscriptionResponse] | None):
         if results is None:
             return
 


### PR DESCRIPTION
This PR moves connection tracking to the lifecycle of a websocket instead of using the incoming session_id or meeting_id.  This avoids the problem of two connections with the same ID causing one to become unusable.